### PR TITLE
Add unit tests for the Java microservices.

### DIFF
--- a/order-service/src/test/java/com/cloudwebshop/orderservice/service/OrderServiceImplTest.java
+++ b/order-service/src/test/java/com/cloudwebshop/orderservice/service/OrderServiceImplTest.java
@@ -3,8 +3,10 @@ package com.cloudwebshop.orderservice.service;
 import com.cloudwebshop.orderservice.model.Order;
 import com.cloudwebshop.orderservice.model.OrderItem;
 import com.cloudwebshop.orderservice.model.OrderStatus;
+import com.cloudwebshop.orderservice.model.OrderStatus;
 import com.cloudwebshop.orderservice.repository.OrderItemRepository;
 import com.cloudwebshop.orderservice.repository.OrderRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,5 +93,77 @@ class OrderServiceImplTest {
         when(orderRepository.findFirstByUserIdAndStatus(userId, OrderStatus.CART)).thenReturn(Optional.of(cart));
         assertThrows(IllegalStateException.class, () -> orderService.createOrderFromCart(userId));
         verify(orderRepository, never()).save(any(Order.class));
+    }
+
+    @Test
+    void updateCartItem_whenItemExists_updatesQuantity() {
+        UUID itemId = UUID.randomUUID();
+        OrderItem item = new OrderItem();
+        item.setId(itemId);
+        item.setQuantity(1);
+        item.setUnitPrice(new BigDecimal("10.00"));
+        cart.getItems().add(item);
+
+        when(orderRepository.findFirstByUserIdAndStatus(userId, OrderStatus.CART)).thenReturn(Optional.of(cart));
+        when(orderRepository.save(any(Order.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Order result = orderService.updateCartItem(userId, itemId, 5);
+
+        assertEquals(1, result.getItems().size());
+        assertEquals(5, result.getItems().get(0).getQuantity());
+        assertEquals(new BigDecimal("50.00"), result.getTotalAmount());
+        verify(orderRepository).save(cart);
+    }
+
+    @Test
+    void updateCartItem_whenItemDoesNotExist_throwsException() {
+        when(orderRepository.findFirstByUserIdAndStatus(userId, OrderStatus.CART)).thenReturn(Optional.of(cart));
+
+        UUID nonExistentItemId = UUID.randomUUID();
+        assertThrows(EntityNotFoundException.class, () -> {
+            orderService.updateCartItem(userId, nonExistentItemId, 5);
+        });
+        verify(orderRepository, never()).save(any(Order.class));
+    }
+
+    @Test
+    void deleteCartItem_whenItemExists_removesItem() {
+        UUID itemId = UUID.randomUUID();
+        OrderItem item = new OrderItem();
+        item.setId(itemId);
+        item.setQuantity(1);
+        item.setUnitPrice(new BigDecimal("10.00"));
+        cart.getItems().add(item);
+
+        when(orderRepository.findFirstByUserIdAndStatus(userId, OrderStatus.CART)).thenReturn(Optional.of(cart));
+
+        orderService.deleteCartItem(userId, itemId);
+
+        assertTrue(cart.getItems().isEmpty());
+        assertEquals(BigDecimal.ZERO, cart.getTotalAmount());
+        verify(orderRepository).save(cart);
+    }
+
+    @Test
+    void deleteCartItem_whenItemDoesNotExist_throwsException() {
+        when(orderRepository.findFirstByUserIdAndStatus(userId, OrderStatus.CART)).thenReturn(Optional.of(cart));
+        UUID nonExistentItemId = UUID.randomUUID();
+        assertThrows(EntityNotFoundException.class, () -> {
+            orderService.deleteCartItem(userId, nonExistentItemId);
+        });
+        verify(orderRepository, never()).save(any(Order.class));
+    }
+
+    @Test
+    void getOrdersForUser_returnsOnlyNonCartOrders() {
+        Order deliveredOrder = new Order();
+        deliveredOrder.setStatus(OrderStatus.DELIVERED);
+        when(orderRepository.findAllByUserIdAndStatusNot(userId, OrderStatus.CART)).thenReturn(Collections.singletonList(deliveredOrder));
+
+        var result = orderService.getOrdersForUser(userId);
+
+        assertEquals(1, result.size());
+        assertEquals(OrderStatus.DELIVERED, result.get(0).getStatus());
+        verify(orderRepository).findAllByUserIdAndStatusNot(userId, OrderStatus.CART);
     }
 }

--- a/user-service/src/test/java/com/cloudwebshop/userservice/service/UserServiceImplTest.java
+++ b/user-service/src/test/java/com/cloudwebshop/userservice/service/UserServiceImplTest.java
@@ -68,4 +68,37 @@ class UserServiceImplTest {
         assertEquals(UserStatus.DELETED, user.getStatus());
         verify(userRepository).save(user);
     }
+
+    @Test
+    void updateUserProfile_whenUserExists_savesAndReturnsUser() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        // Use thenAnswer to return the argument that was passed to the save method
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        User updatedUser = new User();
+        updatedUser.setId(userId);
+        updatedUser.setEmail("new.email@example.com");
+
+        User result = userService.updateUserProfile(updatedUser);
+
+        assertNotNull(result);
+        assertEquals("new.email@example.com", result.getEmail());
+        verify(userRepository).existsById(userId);
+        verify(userRepository).save(updatedUser);
+    }
+
+    @Test
+    void updateUserProfile_whenUserDoesNotExist_throwsEntityNotFoundException() {
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        User updatedUser = new User();
+        updatedUser.setId(userId);
+
+        assertThrows(EntityNotFoundException.class, () -> {
+            userService.updateUserProfile(updatedUser);
+        });
+
+        verify(userRepository).existsById(userId);
+        verify(userRepository, never()).save(any(User.class));
+    }
 }


### PR DESCRIPTION
This commit introduces new unit tests for the `order-service` and `user-service` modules to improve code coverage and ensure the reliability of the business logic.

In `order-service`:
- Added tests for updating and deleting items from the shopping cart.
- Added tests for retrieving a user's order history.
- Covered both success and failure scenarios, such as attempting to modify a non-existent item.

In `user-service`:
- Added tests for the user profile update functionality, including success and "user not found" cases.

All new tests pass and follow the existing testing conventions of using JUnit 5 and Mockito.